### PR TITLE
Fix incorrect connection parameter name causing connection error

### DIFF
--- a/win32wifi/Win32NativeWifiApi.py
+++ b/win32wifi/Win32NativeWifiApi.py
@@ -674,7 +674,7 @@ def WlanOpenHandle():
     client_handle = HANDLE()
     result = func_ref(2, None, byref(negotiated_version), byref(client_handle))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanOpenHandle failed.")
+        raise Exception("WlanOpenHandle failed.", result)
     return client_handle
 
 
@@ -692,7 +692,7 @@ def WlanCloseHandle(hClientHandle):
     func_ref.restype = DWORD
     result = func_ref(hClientHandle, None)
     if result != ERROR_SUCCESS:
-        raise Exception("WlanCloseHandle failed.")
+        raise Exception("WlanCloseHandle failed.", result)
     return result
 
 
@@ -729,7 +729,7 @@ def WlanEnumInterfaces(hClientHandle):
     wlan_ifaces = pointer(WLAN_INTERFACE_INFO_LIST())
     result = func_ref(hClientHandle, None, byref(wlan_ifaces))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanEnumInterfaces failed.")
+        raise Exception("WlanEnumInterfaces failed.", result)
     return wlan_ifaces
 
 
@@ -756,7 +756,7 @@ def WlanScan(hClientHandle, pInterfaceGuid, ssid=""):
     if ssid:
         length = len(ssid)
         if length > DOT11_SSID_MAX_LENGTH:
-            raise Exception("SSIDs have a maximum length of 32 characters.")
+            raise Exception("SSIDs have a maximum length of 32 characters.", length)
         # data = tuple(ord(char) for char in ssid)
         data = ssid
         dot11_ssid = byref(DOT11_SSID(length, data))
@@ -769,7 +769,7 @@ def WlanScan(hClientHandle, pInterfaceGuid, ssid=""):
                       None,
                       None)
     if result != ERROR_SUCCESS:
-        raise Exception("WlanScan failed.")
+        raise Exception("WlanScan failed.", result)
     return result
 
 
@@ -816,7 +816,7 @@ def WlanGetNetworkBssList(hClientHandle, pInterfaceGuid):
                       None,
                       byref(wlan_bss_list))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanGetNetworkBssList failed.")
+        raise Exception("WlanGetNetworkBssList failed.", result)
     return wlan_bss_list
 
 
@@ -847,7 +847,7 @@ def WlanGetAvailableNetworkList(hClientHandle, pInterfaceGuid):
                       None,
                       byref(wlan_available_network_list))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanGetAvailableNetworkList failed.")
+        raise Exception("WlanGetAvailableNetworkList failed.", result)
     return wlan_available_network_list
 
 
@@ -875,7 +875,7 @@ def WlanGetProfileList(hClientHandle, pInterfaceGuid):
                       None,
                       byref(wlan_profile_info_list))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanGetProfileList failed.")
+        raise Exception("WlanGetProfileList failed.", result)
     return wlan_profile_info_list
 
 
@@ -914,7 +914,7 @@ def WlanGetProfile(hClientHandle, pInterfaceGuid, profileName):
                       byref(flags),
                       byref(pdw_granted_access))
     if result != ERROR_SUCCESS:
-        raise Exception("WlanGetProfile failed.")
+        raise Exception("WlanGetProfile failed.", result)
     return xml
 
 def WlanDeleteProfile(hClientHandle, pInterfaceGuid, profileName):
@@ -1030,7 +1030,7 @@ def WlanConnect(hClientHandle, pInterfaceGuid, pConnectionParameters):
                       pointer(pConnectionParameters),
                       None)
     if result != ERROR_SUCCESS:
-        raise Exception("".join(["WlanConnect failed with error ", str(result)]))
+        raise Exception("".join(["WlanConnect failed with error ", str(result)]), result)
     return result
 
 def WlanDisconnect(hClientHandle, pInterfaceGuid):
@@ -1045,7 +1045,7 @@ def WlanDisconnect(hClientHandle, pInterfaceGuid):
                       byref(pInterfaceGuid),
                       None)
     if result != ERROR_SUCCESS:
-        raise Exception("WlanDisconnect failed.")
+        raise Exception("WlanDisconnect failed.", result)
     return result
 
 WLAN_INTF_OPCODE = c_uint
@@ -1182,6 +1182,6 @@ def WlanQueryInterface(hClientHandle, pInterfaceGuid, OpCode):
                       ppData,
                       pWlanOpcodeValueType)
     if result != ERROR_SUCCESS:
-        raise Exception("WlanQueryInterface failed.")
+        raise Exception("WlanQueryInterface failed.", result)
     return ppData
 

--- a/win32wifi/Win32NativeWifiApi.py
+++ b/win32wifi/Win32NativeWifiApi.py
@@ -607,7 +607,7 @@ WLAN_NOTIFICATION_DATA_ACM_TYPES_DICT = {
     WLAN_NOTIFICATION_ACM_ENUM.wlan_notification_acm_scan_list_refresh: None,
 }
 
-def WlanRegisterNotification(hClientHandle, callback):
+def WlanRegisterNotification(hClientHandle, callback, pCallbackContext=None):
     """
         The WlanRegisterNotification function is used to register and 
         unregister notifications on all wireless interfaces.
@@ -641,7 +641,6 @@ def WlanRegisterNotification(hClientHandle, callback):
     dwNotifSource = WLAN_NOTIFICATION_SOURCE_ALL
     bIgnoreDuplicate = True
     funcCallback = WLAN_NOTIFICATION_CALLBACK_M(callback)
-    pCallbackContext = None
     pdwPrevNotifSource = None
 
     result = func_ref(hClientHandle,

--- a/win32wifi/Win32NativeWifiApi.py
+++ b/win32wifi/Win32NativeWifiApi.py
@@ -741,7 +741,7 @@ def WlanScan(hClientHandle, pInterfaceGuid, ssid=""):
         DWORD WINAPI WlanScan(
             _In_        HANDLE hClientHandle,
             _In_        const GUID *pInterfaceGuid,
-            _In_opt_    const PDOT11_SSID pDot11Ssid,
+            _In_opt_    const PDOT11_SSID pDot11_ssid,
             _In_opt_    const PWLAN_RAW_DATA pIeData,
             _Reserved_  PVOID pReserved
         );
@@ -782,7 +782,7 @@ def WlanGetNetworkBssList(hClientHandle, pInterfaceGuid):
         DWORD WINAPI WlanGetNetworkBssList(
             _In_        HANDLE hClientHandle,
             _In_        const GUID *pInterfaceGuid,
-            _In_        const  PDOT11_SSID pDot11Ssid,
+            _In_        const  PDOT11_SSID pDot11_ssid,
             _In_        DOT11_BSS_TYPE dot11BssType,
             _In_        BOOL bSecurityEnabled,
             _Reserved_  PVOID pReserved,
@@ -791,14 +791,14 @@ def WlanGetNetworkBssList(hClientHandle, pInterfaceGuid):
     """
     func_ref = wlanapi.WlanGetNetworkBssList
     # TODO: handle the arguments descibed below.
-    # pDot11Ssid - When set to NULL, the returned list contains all of
+    # pDot11_ssid - When set to NULL, the returned list contains all of
     # available BSS entries on a wireless LAN interface.
     # dot11BssType - The BSS type of the network. This parameter is ignored if
-    # the SSID of the network for the BSS list is unspecified (the pDot11Ssid
+    # the SSID of the network for the BSS list is unspecified (the pDot11_ssid
     # parameter is NULL).
     # bSecurityEnabled - A value that indicates whether security is enabled on
     # the network. This parameter is only valid when the SSID of the network
-    # for the BSS list is specified (the pDot11Ssid parameter is not NULL).
+    # for the BSS list is specified (the pDot11_ssid parameter is not NULL).
     func_ref.argtypes = [HANDLE,
                          POINTER(GUID),
                          c_void_p,
@@ -982,7 +982,7 @@ class WLAN_CONNECTION_PARAMETERS(Structure):
         typedef struct _WLAN_CONNECTION_PARAMETERS {
           WLAN_CONNECTION_MODE wlanConnectionMode;
           LPCWSTR              strProfile;
-          PDOT11_SSID          pDot11Ssid;
+          PDOT11_SSID          pDot11_ssid;
           PDOT11_BSSID_LIST    pDesiredBssidList;
           DOT11_BSS_TYPE       dot11BssType;
           DWORD                dwFlags;

--- a/win32wifi/Win32NativeWifiApi.py
+++ b/win32wifi/Win32NativeWifiApi.py
@@ -741,7 +741,7 @@ def WlanScan(hClientHandle, pInterfaceGuid, ssid=""):
         DWORD WINAPI WlanScan(
             _In_        HANDLE hClientHandle,
             _In_        const GUID *pInterfaceGuid,
-            _In_opt_    const PDOT11_SSID pDot11_ssid,
+            _In_opt_    const PDOT11_SSID pDot11Ssid,
             _In_opt_    const PWLAN_RAW_DATA pIeData,
             _Reserved_  PVOID pReserved
         );
@@ -782,7 +782,7 @@ def WlanGetNetworkBssList(hClientHandle, pInterfaceGuid):
         DWORD WINAPI WlanGetNetworkBssList(
             _In_        HANDLE hClientHandle,
             _In_        const GUID *pInterfaceGuid,
-            _In_        const  PDOT11_SSID pDot11_ssid,
+            _In_        const  PDOT11_SSID pDot11Ssid,
             _In_        DOT11_BSS_TYPE dot11BssType,
             _In_        BOOL bSecurityEnabled,
             _Reserved_  PVOID pReserved,
@@ -791,14 +791,14 @@ def WlanGetNetworkBssList(hClientHandle, pInterfaceGuid):
     """
     func_ref = wlanapi.WlanGetNetworkBssList
     # TODO: handle the arguments descibed below.
-    # pDot11_ssid - When set to NULL, the returned list contains all of
+    # pDot11Ssid - When set to NULL, the returned list contains all of
     # available BSS entries on a wireless LAN interface.
     # dot11BssType - The BSS type of the network. This parameter is ignored if
-    # the SSID of the network for the BSS list is unspecified (the pDot11_ssid
+    # the SSID of the network for the BSS list is unspecified (the pDot11Ssid
     # parameter is NULL).
     # bSecurityEnabled - A value that indicates whether security is enabled on
     # the network. This parameter is only valid when the SSID of the network
-    # for the BSS list is specified (the pDot11_ssid parameter is not NULL).
+    # for the BSS list is specified (the pDot11Ssid parameter is not NULL).
     func_ref.argtypes = [HANDLE,
                          POINTER(GUID),
                          c_void_p,
@@ -982,7 +982,7 @@ class WLAN_CONNECTION_PARAMETERS(Structure):
         typedef struct _WLAN_CONNECTION_PARAMETERS {
           WLAN_CONNECTION_MODE wlanConnectionMode;
           LPCWSTR              strProfile;
-          PDOT11_SSID          pDot11_ssid;
+          PDOT11_SSID          pDot11Ssid;
           PDOT11_BSSID_LIST    pDesiredBssidList;
           DOT11_BSS_TYPE       dot11BssType;
           DWORD                dwFlags;
@@ -1003,7 +1003,7 @@ class WLAN_CONNECTION_PARAMETERS(Structure):
     """
     _fields_ = [("wlanConnectionMode", WLAN_CONNECTION_MODE),
                 ("strProfile", LPCWSTR),
-                ("pDot11_ssid", POINTER(DOT11_SSID)),
+                ("pDot11Ssid", POINTER(DOT11_SSID)),
                 ("pDesiredBssidList", POINTER(DOT11_BSSID_LIST)),
                 ("dot11BssType", DOT11_BSS_TYPE),
                 ("dwFlags", DWORD)]

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -315,8 +315,10 @@ def disconnect(wireless_interface):
     """
     """
     handle = WlanOpenHandle()
-    WlanDisconnect(handle, wireless_interface.guid)
-    WlanCloseHandle(handle)
+    try:
+        WlanDisconnect(handle, wireless_interface.guid)
+    finally:
+        WlanCloseHandle(handle)
 
 # TODO(shaked): There is an error 87 when trying to connect to a wifi network.
 def connect(wireless_interface, connection_params):

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -320,7 +320,7 @@ def disconnect(wireless_interface):
     finally:
         WlanCloseHandle(handle)
 
-# TODO(shaked): There is an error 87 when trying to connect to a wifi network.
+# TODO(shaked): There is an error 87 when trying to connect to a wifi network.  # @TODO - cfati: Check whether still applies.
 def connect(wireless_interface, connection_params):
     """
         The WlanConnect function attempts to connect to a specific network.

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -389,11 +389,10 @@ def connect(wireless_interface, connection_params):
     cnxp.dot11BssType = DOT11_BSS_TYPE(bssType)
     # flags
     cnxp.dwFlags = DWORD(connection_params["flags"])
-    print(cnxp)
-    result = WlanConnect(handle,
-                wireless_interface.guid,
-                cnxp)
-    WlanCloseHandle(handle)
+    try:
+        result = WlanConnect(handle, wireless_interface.guid, cnxp)
+    finally:
+        WlanCloseHandle(handle)
     return result
 
 def dot11bssidToString(dot11Bssid):

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -345,8 +345,10 @@ def connect(wireless_interface, connection_params):
     connection_mode_int = WLAN_CONNECTION_MODE_VK[connection_mode]
     cnxp.wlanConnectionMode = WLAN_CONNECTION_MODE(connection_mode_int)
     # determine strProfile
-    if connection_mode == ('wlan_connection_mode_profile' or           # name
-                           'wlan_connection_mode_temporary_profile'):  # xml
+    if connection_mode in [
+                'wlan_connection_mode_profile',  # name
+                'wlan_connection_mode_temporary_profile'  # xml
+            ]:
         cnxp.strProfile = LPCWSTR(connection_params["profile"])
     else:
         cnxp.strProfile = NULL

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -539,11 +539,11 @@ class WlanEvent(object):
         return self.notificationCode
 
 
-def OnWlanNotification(callback, wlan_notification_data, p):
+def OnWlanNotification(callback, wlan_notification_data, context):
     event = WlanEvent.from_wlan_notification_data(wlan_notification_data)
 
     if event != None:
-        callback(event)
+        callback(event, context)
 
 
 global_callbacks = []
@@ -556,10 +556,10 @@ class NotificationObject(object):
         self.callback = callback
 
 
-def registerNotification(callback):
+def registerNotification(callback, context=None):
     handle = WlanOpenHandle()
 
-    c_back = WlanRegisterNotification(handle, functools.partial(OnWlanNotification, callback))
+    c_back = WlanRegisterNotification(handle, functools.partial(OnWlanNotification, callback), context)
     global_callbacks.append(c_back)
     global_handles.append(handle)
 

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -359,9 +359,9 @@ def connect(wireless_interface, connection_params):
         dot11Ssid = DOT11_SSID()
         dot11Ssid.SSID = connection_params["ssid"]
         dot11Ssid.SSIDLength = len(connection_params["ssid"])
-        cnxp.pDot11Ssid = pointer(dot11Ssid)
+        cnxp.pDot11_ssid = pointer(dot11Ssid)
     else:
-        cnxp.pDot11Ssid = NULL
+        cnxp.pDot11_ssid = NULL
     # bssidList
     # NOTE: Before this can actually support multiple entries,
     #   the DOT11_BSSID_LIST structure must be rewritten to

--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -359,9 +359,9 @@ def connect(wireless_interface, connection_params):
         dot11Ssid = DOT11_SSID()
         dot11Ssid.SSID = connection_params["ssid"]
         dot11Ssid.SSIDLength = len(connection_params["ssid"])
-        cnxp.pDot11_ssid = pointer(dot11Ssid)
+        cnxp.pDot11Ssid = pointer(dot11Ssid)
     else:
-        cnxp.pDot11_ssid = NULL
+        cnxp.pDot11Ssid = NULL
     # bssidList
     # NOTE: Before this can actually support multiple entries,
     #   the DOT11_BSSID_LIST structure must be rewritten to


### PR DESCRIPTION
`pDot11Ssid` field in `WLAN_CONNECTION_PARAMETERS` incorrectly named `pDot11_Ssid`